### PR TITLE
Fix hex editor to properly initialise with HexFiend

### DIFF
--- a/Cocoa/Plug-Ins/Hex Editor/Base.lproj/HexWindow.xib
+++ b/Cocoa/Plug-Ins/Hex Editor/Base.lproj/HexWindow.xib
@@ -1,111 +1,35 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="4514" systemVersion="13B42" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14113" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
-        <deployment defaultVersion="1080" identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="4514"/>
+        <deployment identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14113"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="HexWindowController">
             <connections>
-                <outlet property="copySubmenu" destination="8" id="34"/>
-                <outlet property="hexDelegate" destination="39" id="40"/>
-                <outlet property="message" destination="48" id="57"/>
-                <outlet property="pasteSubmenu" destination="24" id="33"/>
                 <outlet property="textView" destination="89" id="90"/>
                 <outlet property="window" destination="36" id="37"/>
             </connections>
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
-        <customObject id="-3" userLabel="Application"/>
-        <menu title="Menu" id="8" userLabel="Copy Submenu">
-            <items>
-                <menuItem title="Copy Data" keyEquivalent="c" id="9">
-                    <connections>
-                        <action selector="copy:" target="-1" id="12"/>
-                    </connections>
-                </menuItem>
-                <menuItem isSeparatorItem="YES" id="5">
-                    <modifierMask key="keyEquivalentModifierMask" command="YES"/>
-                </menuItem>
-                <menuItem title="Copy ASCII Representation" id="7">
-                    <connections>
-                        <action selector="copyASCII:" target="-1" id="11"/>
-                    </connections>
-                </menuItem>
-                <menuItem title="Copy Hex Representation" id="6">
-                    <connections>
-                        <action selector="copyHex:" target="-1" id="10"/>
-                    </connections>
-                </menuItem>
-            </items>
-            <connections>
-                <outlet property="delegate" destination="39" id="62"/>
-            </connections>
-        </menu>
-        <menu title="Menu" id="24" userLabel="Paste Submenu">
-            <items>
-                <menuItem title="Paste Data" keyEquivalent="v" id="23">
-                    <connections>
-                        <action selector="paste:" target="-1" id="38"/>
-                    </connections>
-                </menuItem>
-                <menuItem isSeparatorItem="YES" id="26">
-                    <modifierMask key="keyEquivalentModifierMask" command="YES"/>
-                </menuItem>
-                <menuItem title="Paste As ASCII" id="27">
-                    <connections>
-                        <action selector="pasteAsASCII:" target="-1" id="28"/>
-                    </connections>
-                </menuItem>
-                <menuItem title="Paste As Unicode" id="29">
-                    <connections>
-                        <action selector="pasteAsUnicode:" target="-1" id="30"/>
-                    </connections>
-                </menuItem>
-                <menuItem title="Paste As Hexadecimal" id="31">
-                    <connections>
-                        <action selector="pasteAsHex:" target="-1" id="32"/>
-                    </connections>
-                </menuItem>
-                <menuItem title="Paste From Hexadecimal" id="78">
-                    <connections>
-                        <action selector="pasteFromHex:" target="-1" id="80"/>
-                    </connections>
-                </menuItem>
-            </items>
-            <connections>
-                <outlet property="delegate" destination="39" id="61"/>
-            </connections>
-        </menu>
-        <window title="Untitled Resource" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" wantsToBeColor="NO" visibleAtLaunch="NO" animationBehavior="default" id="36" userLabel="Hex Window">
+        <customObject id="-3" userLabel="Application" customClass="NSObject"/>
+        <window title="Untitled Resource" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" visibleAtLaunch="NO" animationBehavior="default" id="36" userLabel="Hex Window">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="387" y="534" width="570" height="319"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1058"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="2069" height="1183"/>
             <value key="minSize" type="size" width="300" height="140"/>
             <view key="contentView" id="35">
                 <rect key="frame" x="0.0" y="0.0" width="570" height="319"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="48">
-                        <rect key="frame" x="4" y="2" width="546" height="17"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
-                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" id="82">
-                            <font key="font" metaFont="system"/>
-                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                        </textFieldCell>
-                    </textField>
                     <customView translatesAutoresizingMaskIntoConstraints="NO" id="89" customClass="HFTextView">
                         <rect key="frame" x="0.0" y="0.0" width="570" height="319"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                     </customView>
                 </subviews>
                 <constraints>
-                    <constraint firstItem="48" firstAttribute="leading" secondItem="35" secondAttribute="leading" constant="6" id="01O-LK-eI8"/>
                     <constraint firstItem="89" firstAttribute="top" secondItem="35" secondAttribute="top" id="Lbc-WD-ZCq"/>
-                    <constraint firstAttribute="trailing" secondItem="48" secondAttribute="trailing" constant="22" id="QKI-ES-Nu5"/>
-                    <constraint firstAttribute="bottom" secondItem="48" secondAttribute="bottom" constant="2" id="bp6-rQ-Vig"/>
                     <constraint firstAttribute="trailing" secondItem="89" secondAttribute="trailing" id="dzv-Wr-QDH"/>
                     <constraint firstAttribute="bottom" secondItem="89" secondAttribute="bottom" id="kd8-uo-IN6"/>
                     <constraint firstItem="89" firstAttribute="leading" secondItem="35" secondAttribute="leading" id="sap-uy-aFS"/>
@@ -115,11 +39,5 @@
                 <outlet property="delegate" destination="-2" id="68"/>
             </connections>
         </window>
-        <customObject id="39" userLabel="HexEditorDelegate" customClass="HexEditorDelegate">
-            <connections>
-                <outlet property="controller" destination="-2" id="41"/>
-                <outlet property="message" destination="48" id="52"/>
-            </connections>
-        </customObject>
     </objects>
 </document>

--- a/Cocoa/Plug-Ins/Hex Editor/FindSheetController.m
+++ b/Cocoa/Plug-Ins/Hex Editor/FindSheetController.m
@@ -39,7 +39,7 @@
 	[self window];
 	
 	// enable/disable boxes
-	[searchSelectionOnlyBox setEnabled:([(NSTextView *)[[sender window] firstResponder] rangeForUserTextChange].length != 0)];
+	[searchSelectionOnlyBox setEnabled:([[[[(HexWindowController *)sender textView] controller] selectedContentsRanges][0] HFRange].length != 0)];
 	
 	// set inital values
 	if( ![searchSelectionOnlyBox isEnabled] )	[searchSelectionOnlyBox setIntValue:0];

--- a/Cocoa/Plug-Ins/Hex Editor/HexWindowController.h
+++ b/Cocoa/Plug-Ins/Hex Editor/HexWindowController.h
@@ -1,6 +1,4 @@
 #import <Cocoa/Cocoa.h>
-#import "HexEditorDelegate.h"
-#import "HexTextView.h"
 #import <HexFiend/HexFiend.h>
 
 #import "ResKnifePluginProtocol.h"
@@ -22,26 +20,15 @@
 
 @interface HexWindowController : NSWindowController <ResKnifePlugin>
 {
-	IBOutlet HexEditorDelegate	*hexDelegate;
-	IBOutlet NSTextView			*offset;		// these four should be phased out whenever possible
-	IBOutlet HexTextView		*hex;			// these four should be phased out whenever possible
-	IBOutlet AsciiTextView		*ascii;			// these four should be phased out whenever possible
-	IBOutlet NSTextField		*message;		// these four should be phased out whenever possible
-	IBOutlet NSMenu				*copySubmenu;
-	IBOutlet NSMenu				*pasteSubmenu;
-	
 	FindSheetController			*sheetController;
 	
 	id <ResKnifeResource>	resource;
 	id <ResKnifeResource>	backup;
 	
 	BOOL			liveEdit;
-	int				bytesPerRow;
 	NSUndoManager   *undoManager;
-
-	IBOutlet HFTextView		*textView;
-	HFController			*textViewController;
 }
+@property (weak) IBOutlet HFTextView *textView;
 
 // conform to the ResKnifePlugin with the inclusion of these methods
 - (instancetype)initWithResource:(id)newResource;
@@ -62,14 +49,5 @@
 // accessors
 - (id)resource;
 - (NSData *)data;
-- (int)bytesPerRow;
-- (NSMenu *)copySubmenu;
-- (NSMenu *)pasteSubmenu;
-
-// bug: these should be functions not class member methods
-+ (NSRange)byteRangeFromHexRange:(NSRange)hexRange;
-+ (NSRange)hexRangeFromByteRange:(NSRange)byteRange;
-+ (NSRange)byteRangeFromAsciiRange:(NSRange)asciiRange;
-+ (NSRange)asciiRangeFromByteRange:(NSRange)byteRange;
 
 @end

--- a/Cocoa/Plug-Ins/Hex Editor/HexWindowController.m
+++ b/Cocoa/Plug-Ins/Hex Editor/HexWindowController.m
@@ -20,6 +20,7 @@ OSStatus Plug_InitInstance(Plug_PlugInRef plug, Plug_ResourceRef resource)
 */
 
 @implementation HexWindowController
+@synthesize textView;
 
 - (instancetype)initWithResource:(id)newResource
 {
@@ -39,7 +40,6 @@ OSStatus Plug_InitInstance(Plug_PlugInRef plug, Plug_ResourceRef resource)
 		resource = [newResource copy];		// resource to work on
 		backup = newResource;		// actual resource to change when saving data and monitor for external changes
 	}
-	bytesPerRow = 16;
 	
 	// load the window from the nib file
 	[self window];
@@ -55,34 +55,23 @@ OSStatus Plug_InitInstance(Plug_PlugInRef plug, Plug_ResourceRef resource)
 {
 	[super windowDidLoad];
 	
-	{
-		// set up tab, shift-tab and enter behaviour (cannot set these in IB at the moment)
-		[hex setFieldEditor:YES];
-		[ascii setFieldEditor:YES];
-		[offset setDrawsBackground:NO];
-		[[offset enclosingScrollView] setDrawsBackground:NO];
-		
-		// IB fonts get ignored for some reason
-		NSFont *courier = [[NSFontManager sharedFontManager] fontWithFamily:@"Courier" traits:0 weight:5 size:12.0];
-		[hex setFont:courier];
-		[ascii setFont:courier];
-		[offset setFont:courier];
-		
-		// from HexEditorDelegate, here until bug is fixed
-		[[NSNotificationCenter defaultCenter] addObserver:hexDelegate selector:@selector(viewDidScroll:) name:NSViewBoundsDidChangeNotification object:[[offset enclosingScrollView] contentView]];
-		[[NSNotificationCenter defaultCenter] addObserver:hexDelegate selector:@selector(viewDidScroll:) name:NSViewBoundsDidChangeNotification object:[[hex enclosingScrollView] contentView]];
-		[[NSNotificationCenter defaultCenter] addObserver:hexDelegate selector:@selector(viewDidScroll:) name:NSViewBoundsDidChangeNotification object:[[ascii enclosingScrollView] contentView]];
-	}
-	
-	// insert the resources' data into the text fields
-	[[self window] setResizeIncrements:NSMakeSize(kWindowStepWidthPerChar * kWindowStepCharsPerStep, 1)];
-	// min 346, step 224, norm 570, step 224, max 794
-	
 	// here because we don't want these notifications until we have a window! (Only register for notifications on the resource we're editing)
 	[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(resourceNameDidChange:) name:ResourceNameDidChangeNotification object:resource];
 	[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(resourceDataDidChange:) name:ResourceDataDidChangeNotification object:resource];
 	if(liveEdit)	[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(resourceWasSaved:) name:ResourceDataDidChangeNotification object:resource];
-	else			[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(resourceWasSaved:) name:ResourceDataDidChangeNotification object:backup];
+    else			[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(resourceWasSaved:) name:ResourceDataDidChangeNotification object:backup];
+    
+    HFLineCountingRepresenter *lineCountingRepresenter = [[HFLineCountingRepresenter alloc] init];
+    HFStatusBarRepresenter *statusBarRepresenter = [[HFStatusBarRepresenter alloc] init];
+    
+    [[textView layoutRepresenter] addRepresenter:lineCountingRepresenter];
+    [[textView layoutRepresenter] addRepresenter:statusBarRepresenter];
+    // bug: lineCountingRepresenter doesn't correctly adjust for the nicer font
+    //[[textView controller] setFont:[NSFont userFixedPitchFontOfSize:10.0]];
+    [[textView controller] addRepresenter:lineCountingRepresenter];
+    [[textView controller] addRepresenter:statusBarRepresenter];
+    [textView bind:@"data" toObject:self withKeyPath:@"data" options:nil];
+    [lineCountingRepresenter cycleLineNumberFormat];
 	
 	// finally, set the window title & show the window
 	[[self window] setTitle:[resource defaultWindowTitle]];
@@ -93,58 +82,6 @@ OSStatus Plug_InitInstance(Plug_PlugInRef plug, Plug_ResourceRef resource)
 - (NSString *)windowTitleForDocumentDisplayName:(NSString *)displayName
 {
 	return [resource defaultWindowTitle];
-}
-
-- (void)windowDidResize:(NSNotification *)notification
-{
-	CGFloat width = [[(NSWindow *)[notification object] contentView] frame].size.width;
-	int oldBytesPerRow = bytesPerRow;
-	bytesPerRow = (int)((((width - (kWindowStepWidthPerChar * kWindowStepCharsPerStep) - 122) / (kWindowStepWidthPerChar * kWindowStepCharsPerStep)) + 1) * kWindowStepCharsPerStep);
-	if(bytesPerRow != oldBytesPerRow)
-		[offset	setString:[hexDelegate offsetRepresentation:[resource data]]];
-	[[hex enclosingScrollView] setFrameSize:NSMakeSize((bytesPerRow * 21) + 5, [[hex enclosingScrollView] frame].size.height)];
-	[[ascii enclosingScrollView] setFrameOrigin:NSMakePoint((bytesPerRow * 21) + 95, 20)];
-	[[ascii enclosingScrollView] setFrameSize:NSMakeSize((bytesPerRow * 7) + 28, [[ascii enclosingScrollView] frame].size.height)];
-}
-
-- (void)windowDidBecomeKey:(NSNotification *)notification
-{
-	NSMenu *editMenu = [[[NSApp mainMenu] itemAtIndex:2] submenu];
-	NSMenuItem *copyItem = [editMenu itemAtIndex:[editMenu indexOfItemWithTarget:nil andAction:@selector(copy:)]];
-	NSMenuItem *pasteItem = [editMenu itemAtIndex:[editMenu indexOfItemWithTarget:nil andAction:@selector(paste:)]];
-	
-	// swap copy: menu item for my own copy submenu
-	[copyItem setEnabled:YES];
-	[copyItem setKeyEquivalent:@"\0"];		// clear key equiv.
-	[copyItem setKeyEquivalentModifierMask:0];
-	[editMenu setSubmenu:copySubmenu forItem:copyItem];
-	
-	// swap paste: menu item for my own paste submenu
-	[pasteItem setEnabled:YES];
-	[pasteItem setKeyEquivalent:@"\0"];
-	[pasteItem setKeyEquivalentModifierMask:0];
-	[editMenu setSubmenu:pasteSubmenu forItem:pasteItem];
-}
-
-- (void)windowDidResignKey:(NSNotification *)notification
-{
-	NSMenu *editMenu = [[[NSApp mainMenu] itemAtIndex:2] submenu];
-	NSMenuItem *copyItem = [editMenu itemAtIndex:[editMenu indexOfItemWithSubmenu:copySubmenu]];
-	NSMenuItem *pasteItem = [editMenu itemAtIndex:[editMenu indexOfItemWithSubmenu:pasteSubmenu]];
-	
-	// swap my submenu for plain copy menu item
-	[editMenu setSubmenu:nil forItem:copyItem];
-	[copyItem setTarget:nil];
-	[copyItem setAction:@selector(copy:)];
-	[copyItem setKeyEquivalent:@"c"];
-	[copyItem setKeyEquivalentModifierMask:NSCommandKeyMask];
-	
-	// swap my submenu for plain paste menu item
-	[editMenu setSubmenu:nil forItem:pasteItem];
-	[pasteItem setTarget:nil];
-	[pasteItem setAction:@selector(paste:)];
-	[pasteItem setKeyEquivalent:@"v"];
-	[pasteItem setKeyEquivalentModifierMask:NSCommandKeyMask];
 }
 
 - (BOOL)windowShouldClose:(id)sender
@@ -234,43 +171,6 @@ OSStatus Plug_InitInstance(Plug_PlugInRef plug, Plug_ResourceRef resource)
 	}
 }
 
-- (void)refreshData:(NSData *)data;
-{
-	// save selections
-	NSRange hexSelection = [hex selectedRange];
-	NSRange asciiSelection = [ascii selectedRange];
-	
-	// clear delegates (see HexEditorDelegate class for explanation of why)
-	id oldDelegate = [hex delegate];
-	[hex setDelegate:nil];
-	[ascii setDelegate:nil];
-	
-	// prepare attributes dictionary
-	NSMutableParagraphStyle *paragraph = [[NSParagraphStyle defaultParagraphStyle] mutableCopy];
-	[paragraph setLineBreakMode:NSLineBreakByCharWrapping];
-	NSDictionary *dictionary = [NSDictionary dictionaryWithObject:paragraph forKey:NSParagraphStyleAttributeName];
-	
-	// do stuff with data
-	[offset setString:[hexDelegate offsetRepresentation:data]];
-	if([data length] > 0)
-		[hex setString:[[data hexRepresentation] stringByAppendingString:@" "]];
-	else [hex setString:[data hexRepresentation]];
-	[ascii setString:[data asciiRepresentation]];
-	
-	// apply attributes
-	[[offset textStorage] addAttributes:dictionary range:NSMakeRange(0, [[offset textStorage] length])];
-	[[hex	 textStorage] addAttributes:dictionary range:NSMakeRange(0, [[hex textStorage] length])];
-	[[ascii	 textStorage] addAttributes:dictionary range:NSMakeRange(0, [[ascii textStorage] length])];
-	
-	// restore selections (this is the dumbest way to do it, but it'll do for now)
-	[hex setSelectedRange:NSIntersectionRange(hexSelection, [hex selectedRange])];
-	[ascii setSelectedRange:NSIntersectionRange(asciiSelection, [ascii selectedRange])];
-	
-	// restore delegates
-	[hex setDelegate:oldDelegate];
-	[ascii setDelegate:oldDelegate];
-}
-
 - (id)resource
 {
 	return resource;
@@ -286,56 +186,9 @@ OSStatus Plug_InitInstance(Plug_PlugInRef plug, Plug_ResourceRef resource)
 	resource.data = data;
 }
 
-- (int)bytesPerRow
-{
-	return bytesPerRow;
-}
-
-- (NSMenu *)copySubmenu
-{
-	return copySubmenu;
-}
-
-- (NSMenu *)pasteSubmenu
-{
-	return pasteSubmenu;
-}
-
 - (NSUndoManager *)windowWillReturnUndoManager:(NSWindow *)sender
 {
 	return undoManager;
-}
-
-/* range conversion methods */
-
-+ (NSRange)byteRangeFromHexRange:(NSRange)hexRange
-{
-	// valid for all window widths
-	NSRange byteRange = NSMakeRange(0,0);
-	byteRange.location = (hexRange.location / 3);
-	byteRange.length = (hexRange.length / 3) + ((hexRange.length % 3)? 1:0);
-	return byteRange;
-}
-
-+ (NSRange)hexRangeFromByteRange:(NSRange)byteRange
-{
-	// valid for all window widths
-	NSRange hexRange = NSMakeRange(0,0);
-	hexRange.location = (byteRange.location * 3);
-	hexRange.length = (byteRange.length * 3) - ((byteRange.length > 0)? 1:0);
-	return hexRange;
-}
-
-+ (NSRange)byteRangeFromAsciiRange:(NSRange)asciiRange
-{
-	// one-to-one mapping
-	return asciiRange;
-}
-
-+ (NSRange)asciiRangeFromByteRange:(NSRange)byteRange
-{
-	// one-to-one mapping
-	return byteRange;
 }
 
 @end

--- a/ResKnife.xcodeproj/project.pbxproj
+++ b/ResKnife.xcodeproj/project.pbxproj
@@ -144,13 +144,9 @@
 		E18BF588069FEA1300F076B8 /* Carbon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F5B5884A0156D40B01000001 /* Carbon.framework */; };
 		E18BF590069FEA1400F076B8 /* ResKnifeResourceProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = F5CDEBAB01FC893201A80001 /* ResKnifeResourceProtocol.h */; };
 		E18BF591069FEA1400F076B8 /* ResKnifePluginProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = F5502C4001C579FF01C57124 /* ResKnifePluginProtocol.h */; };
-		E18BF592069FEA1400F076B8 /* HexEditorDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = F5EF83A0020C08E601A80001 /* HexEditorDelegate.h */; };
-		E18BF593069FEA1400F076B8 /* HexTextView.h in Headers */ = {isa = PBXBuildFile; fileRef = F5EF83A2020C08E601A80001 /* HexTextView.h */; };
 		E18BF594069FEA1400F076B8 /* HexWindowController.h in Headers */ = {isa = PBXBuildFile; fileRef = F5EF83A7020C08E601A80001 /* HexWindowController.h */; };
 		E18BF595069FEA1400F076B8 /* FindSheetController.h in Headers */ = {isa = PBXBuildFile; fileRef = F54E6220021B6A0801A80001 /* FindSheetController.h */; };
 		E18BF596069FEA1400F076B8 /* NSData-HexRepresentation.h in Headers */ = {isa = PBXBuildFile; fileRef = E1C5E08B055D98790001A04A /* NSData-HexRepresentation.h */; };
-		E18BF59B069FEA1400F076B8 /* HexEditorDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = F5EF83A1020C08E601A80001 /* HexEditorDelegate.m */; };
-		E18BF59C069FEA1400F076B8 /* HexTextView.m in Sources */ = {isa = PBXBuildFile; fileRef = F5EF83A3020C08E601A80001 /* HexTextView.m */; };
 		E18BF59D069FEA1400F076B8 /* HexWindowController.m in Sources */ = {isa = PBXBuildFile; fileRef = F5EF83A8020C08E601A80001 /* HexWindowController.m */; };
 		E18BF59E069FEA1400F076B8 /* FindSheetController.m in Sources */ = {isa = PBXBuildFile; fileRef = F54E6221021B6A0801A80001 /* FindSheetController.m */; };
 		E18BF59F069FEA1400F076B8 /* Notifications.m in Sources */ = {isa = PBXBuildFile; fileRef = F5C9ECCE027F474A01A8010C /* Notifications.m */; };
@@ -1298,8 +1294,6 @@
 			files = (
 				E18BF590069FEA1400F076B8 /* ResKnifeResourceProtocol.h in Headers */,
 				E18BF591069FEA1400F076B8 /* ResKnifePluginProtocol.h in Headers */,
-				E18BF592069FEA1400F076B8 /* HexEditorDelegate.h in Headers */,
-				E18BF593069FEA1400F076B8 /* HexTextView.h in Headers */,
 				E18BF594069FEA1400F076B8 /* HexWindowController.h in Headers */,
 				E18BF595069FEA1400F076B8 /* FindSheetController.h in Headers */,
 				E18BF596069FEA1400F076B8 /* NSData-HexRepresentation.h in Headers */,
@@ -1943,8 +1937,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E18BF59B069FEA1400F076B8 /* HexEditorDelegate.m in Sources */,
-				E18BF59C069FEA1400F076B8 /* HexTextView.m in Sources */,
 				E18BF59D069FEA1400F076B8 /* HexWindowController.m in Sources */,
 				E18BF59E069FEA1400F076B8 /* FindSheetController.m in Sources */,
 				E18BF59F069FEA1400F076B8 /* Notifications.m in Sources */,


### PR DESCRIPTION
Since this fork seems to be the most modern (thanks for the work here!), I thought maybe I'd submit some PRs. Let me know if you'd rather I didn't, it's just a bit confusing as there are a number of forks and they're all out of sync (probably doesn't help that slobo/ResKnife is not a direct fork of nickshanks/ResKnife).

Anyway, this PR fixes the hex editor, adding back in some lines that had been lost that initialise the HexFiend view. I also cleaned out a lot of defunct code from the previous implementation.